### PR TITLE
Allow opting into bot PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: commit message to use for autofixing
     required: false
     default: '[pre-commit.ci lite] apply automatic fixes'
+  skip_bots:
+    description: if true, skip PRs created by bots
+    required: false
+    default: 'true'
 runs:
   using: node20
   main: main.mjs

--- a/main.mjs
+++ b/main.mjs
@@ -8,7 +8,7 @@ const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH));
 if (process.env.GITHUB_EVENT_NAME !== 'pull_request') {
     console.log('skip: not a pull request');
     process.exit(0);
-} else if (event.sender.type !== 'User') {
+} else if (process.env.INPUT_SKIP_BOTS === 'true' && event.sender.type !== 'User') {
     console.log('skip: triggered by a bot');
     process.exit(0);
 }


### PR DESCRIPTION
There are some scenarios where running pre-commit with PRs from GitHub bots can be particularly useful. This is especially true with Dependabot or Renovate PRs where pre-commit may perform additional steps that neither Dependabot or Renovate support out of the box.

In one example, despite having Renovate configured to run `go mod tidy` after updating Go dependencies, our pre-commit hooks result in additional changes (due to the use of Go workspaces), resulting in a failed `pre-commit` status check due to changed files.

It would immensely useful if this action could be used to commit the changes back to the PR automatically as it does for all other PRs in our repo.
 