### PR TITLE
Update index before diff-index to check if there are changes

### DIFF
--- a/bin/main
+++ b/bin/main
@@ -26,11 +26,20 @@ _GIT = (
 
 
 def _has_changes(*, src_repo: str) -> bool:
-    cmd = (
+    # Without updating the index, diff-index may say that there
+    # are changes when there are not.
+    # For example, if a file has been written to but its contents
+    # have not changed.
+    update_index_cmd = (
+        *_GIT, '-C', src_repo, 'update-index', '--refresh',
+    )
+    subprocess.call(update_index_cmd)
+
+    diff_index_cmd = (
         *_GIT, '-C', src_repo, 'diff-index',
         '--quiet', '--no-ext-diff', 'HEAD', '--',
     )
-    return subprocess.call(cmd) == 1
+    return subprocess.call(diff_index_cmd) == 1
 
 
 def _rev_parse(*, repo: str, ref: str) -> str:


### PR DESCRIPTION
Thank you @asottile for the tooling and apologies for the earlier spamming.

It is possible to get to a state where diff-index shows that there is a diff, but there is nothing to commit.
For example, when overwriting a file with its current context.

Experiment:

```
$ echo hello > foo.txt
$ git add foo.txt
$ git diff-index --no-ext-diff HEAD --
:000000 100644 0000000000000000000000000000000000000000 ce013625030ba8dba906f756967f9e9ca394464a A      foo.txt
$ git commit -m "Add foo.txt"
[experiment b237cf0] Add foo.txt
 1 file changed, 1 insertion(+)
 create mode 100644 foo.txt
$ git diff-index --no-ext-diff HEAD --
$ echo hello > foo.txt
$ git diff-index --no-ext-diff HEAD --
:100644 100644 ce013625030ba8dba906f756967f9e9ca394464a 0000000000000000000000000000000000000000 M      foo.txt
$ git commit -a
On branch experiment
nothing to commit, working tree clean
$
```

This scenario led to a confusing error:

```
Traceback (most recent call last):
  File "/home/runner/work/_actions/pre-commit-ci/lite-action/v1.0.2/bin/main", line 298, in <module>
    raise SystemExit(main())
                     ^^^^^^
  File "/home/runner/work/_actions/pre-commit-ci/lite-action/v1.0.2/bin/main", line 270, in main
    commit = _make_commit(src_repo=args.src_repo, head=head, clone=clone)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/pre-commit-ci/lite-action/v1.0.2/bin/main", line 57, in _make_commit
    subprocess.check_call(
  File "/opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('git', '-c', 'user.name=does-not-matter', '-c', 'user.email=does-not-matter@example.com', '-c', 'protocol.version=2', '-C', '.', 'commit', '--all', '--quiet', '--no-edit', '--no-verify', '--message=hi')' returned non-zero exit status 1.
```

This change refreshes the index before diff-ing it, avoiding the error.